### PR TITLE
Upgrading to Quarkus 3.0

### DIFF
--- a/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/CompasSclAutoAlignmentConfiguration.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/CompasSclAutoAlignmentConfiguration.java
@@ -6,8 +6,8 @@ package org.lfenergy.compas.scl.auto.alignment.rest;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.lfenergy.compas.core.commons.ElementConverter;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
 
 /**
  * Create Beans from other dependencies that are used in the application.

--- a/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/monitoring/LivenessHealthCheck.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/monitoring/LivenessHealthCheck.java
@@ -7,7 +7,7 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @Liveness
 @ApplicationScoped

--- a/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/monitoring/ReadinessHealthCheck.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/monitoring/ReadinessHealthCheck.java
@@ -7,7 +7,7 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @Readiness
 @ApplicationScoped

--- a/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/v1/SclAutoAlignmentResource.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/v1/SclAutoAlignmentResource.java
@@ -13,14 +13,14 @@ import org.lfenergy.compas.scl.auto.alignment.rest.v1.model.SclAutoAlignResponse
 import org.lfenergy.compas.scl.auto.alignment.rest.v1.model.SclAutoAlignSVGRequest;
 import org.lfenergy.compas.scl.auto.alignment.service.SclAutoAlignmentService;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.validation.Valid;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Authenticated
 @RequestScoped

--- a/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/v1/model/SclAutoAlignRequest.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/v1/model/SclAutoAlignRequest.java
@@ -6,12 +6,12 @@ package org.lfenergy.compas.scl.auto.alignment.rest.v1.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/v1/model/SclAutoAlignResponse.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/v1/model/SclAutoAlignResponse.java
@@ -5,10 +5,10 @@ package org.lfenergy.compas.scl.auto.alignment.rest.v1.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static org.lfenergy.compas.scl.auto.alignment.SclAutoAlignmentConstants.SCL_AUTO_ALIGNMENT_SERVICE_V1_NS_URI;
 

--- a/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/v1/model/SclAutoAlignSVGRequest.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/v1/model/SclAutoAlignSVGRequest.java
@@ -6,11 +6,11 @@ package org.lfenergy.compas.scl.auto.alignment.rest.v1.model;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-import javax.validation.constraints.NotBlank;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import static org.lfenergy.compas.scl.auto.alignment.SclAutoAlignmentConstants.SCL_AUTO_ALIGNMENT_SERVICE_V1_NS_URI;
 

--- a/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/v1/model/package-info.java
+++ b/app/src/main/java/org/lfenergy/compas/scl/auto/alignment/rest/v1/model/package-info.java
@@ -8,7 +8,7 @@
 )
 package org.lfenergy.compas.scl.auto.alignment.rest.v1.model;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;
 
 import static org.lfenergy.compas.scl.auto.alignment.SclAutoAlignmentConstants.SCL_AUTO_ALIGNMENT_SERVICE_V1_NS_URI;

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -18,8 +18,8 @@ quarkus.index-dependency.compas-commons.artifact-id = commons
 quarkus.index-dependency.rest-commons.group-id    = org.lfenergy.compas.core
 quarkus.index-dependency.rest-commons.artifact-id = rest-commons
 
-quarkus.index-dependency.jaxb-api.group-id    = org.jboss.spec.javax.xml.bind
-quarkus.index-dependency.jaxb-api.artifact-id = jboss-jaxb-api_2.3_spec
+quarkus.index-dependency.jaxb-api.group-id    = jakarta.xml.bind
+quarkus.index-dependency.jaxb-api.artifact-id = jakarta.xml.bind-api
 
 quarkus.index-dependency.powsybl-single-line-diagram-core.group-id=com.powsybl
 quarkus.index-dependency.powsybl-single-line-diagram-core.artifact-id=powsybl-single-line-diagram-core

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <sonarqube-plugin.version>3.2.0</sonarqube-plugin.version>
 
-        <compas.core.version>0.11.0</compas.core.version>
+        <compas.core.version>0.16.0</compas.core.version>
 
         <quarkus.platform.version>3.0.4.Final</quarkus.platform.version>
         <log4j2.version>2.20.0</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: Apache-2.0
 
         <compas.core.version>0.11.0</compas.core.version>
 
-        <quarkus.platform.version>2.16.6.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.0.4.Final</quarkus.platform.version>
         <log4j2.version>2.20.0</log4j2.version>
         <powsybl.sld.version>3.2.0</powsybl.sld.version>
         <gson.version>2.10.1</gson.version>
@@ -56,8 +56,8 @@ SPDX-License-Identifier: Apache-2.0
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-universe-bom</artifactId>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/service/src/main/java/org/lfenergy/compas/scl/auto/alignment/service/SclAutoAlignmentService.java
+++ b/service/src/main/java/org/lfenergy/compas/scl/auto/alignment/service/SclAutoAlignmentService.java
@@ -15,8 +15,8 @@ import org.lfenergy.compas.scl.auto.alignment.builder.SubstationGraphBuilder;
 import org.lfenergy.compas.scl.auto.alignment.exception.SclAutoAlignmentException;
 import org.lfenergy.compas.scl.auto.alignment.model.GenericSCL;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;


### PR DESCRIPTION
the main change is migrating from JavaEE to JakartaEE.

- update Quarkus bom from io.quarkus:quarkus-universe-bom to io.quarkus.platform:quarkus-bom as it was deprecated since Quarkus 2.1 https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.1#quarkus-universe-bom-is-deprecated (and it is required to use the Quarkus migration tool)
- launched quarkus `quarkus update --stream=3.0` as mentioned in https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#automatic-update-tool which dealt with a fair part of the migration. Then it remained few little tasks.
- Updated quarkus.index-dependency for jaxb from org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec to `jakarta.xml.bind:jakarta.xml.bind-api`

fix #202